### PR TITLE
Added `cargo` installation for successful Google Colab run

### DIFF
--- a/Video_Killed_The_Radio_Star_Defusion.ipynb
+++ b/Video_Killed_The_Radio_Star_Defusion.ipynb
@@ -125,6 +125,7 @@
         "%%capture\n",
         "\n",
         "# @title # 🛠️ Installations\n",
+        "!apt-get install cargo\n",
         "!pip install vktrs[api,hf]\n",
         "\n",
         "!pip install git+https://github.com/openai/whisper@v20230314\n",


### PR DESCRIPTION
This fixes #136, #137 - when running `vktrs` in Google Colab fails due to dependencies unable to be installed.
The `pytokenizations` package doesn't include a wheel for colab, so trying to build the package fails because `cargo` in not installed on colab.

This PR was tested and passed.

![image](https://user-images.githubusercontent.com/88027106/235440332-03f476bf-761e-416d-8959-5dee9e5fbc8f.png)
![image](https://user-images.githubusercontent.com/88027106/235440348-7fc825fb-4737-4148-8885-ae1e3e95b473.png)
